### PR TITLE
Reverse time for each key

### DIFF
--- a/addons/godot-animation-reverser/helper.gd
+++ b/addons/godot-animation-reverser/helper.gd
@@ -58,7 +58,7 @@ static func reverse(animation_player: AnimationPlayer, anim_name: String, new_na
 		# Now we'll start to setup the tracks on the new animation
 		for key_idx in range(len(key_items)):
 			var key_item = key_items[key_idx]
-			new_anim.track_set_key_time(track_idx, key_idx, key_item[0])
+			new_anim.track_set_key_time(track_idx, key_idx, anim.get_length() - key_item[0])
 			new_anim.track_set_key_value(track_idx, key_idx, key_item[1])
 			new_anim.track_set_key_transition(track_idx, key_idx, key_item[2])
 

--- a/addons/godot-animation-reverser/plugin.cfg
+++ b/addons/godot-animation-reverser/plugin.cfg
@@ -5,5 +5,5 @@ description="Adds a tool button in Project -> Tools that can reverse the keyfram
 
 NOTE: This button will only show when an AnimationPlayer has been selected."
 author="William Whitty (willwhitty.com)"
-version="1.0"
+version="1.1"
 script="plugin.gd"


### PR DESCRIPTION
In the current implementation, the value of each key in the reversed track is set with the correct value (ex. the first key in the reversed track has the value of the last key in the non-reversed track) as expected. The time of the reversed keys, however, are not being set correctly. They should be set relative to the end of the track instead of the beginning. In the current implementation, I get this:

<img width="541" alt="Screen Shot 2024-12-07 at 9 57 55 AM" src="https://github.com/user-attachments/assets/42666b44-d5d2-44f8-9a7c-00e6b7b51f4f">
<img width="507" alt="Screen Shot 2024-12-07 at 9 58 03 AM" src="https://github.com/user-attachments/assets/c30525d9-1d32-4948-868e-78db36219666">

With my change, I instead get this:

<img width="506" alt="Screen Shot 2024-12-07 at 9 58 31 AM" src="https://github.com/user-attachments/assets/ce7d1695-50a1-4f4c-a42d-3dabb7954aa8">

Which not only reverses the values, but also their position on the timeline. This matches the behavior of the `play_backwards` method.